### PR TITLE
Add enterprise-grade navigation and links

### DIFF
--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -1,0 +1,26 @@
+import { Link } from "react-router-dom";
+
+const AboutSection = () => (
+  <section id="about" className="py-24 bg-background">
+    <div className="container mx-auto px-4 text-center space-y-6">
+      <h2 className="text-4xl font-bold">About</h2>
+      <p className="text-muted-foreground max-w-2xl mx-auto">
+        Learn more about our mission, leadership team, and press resources.
+      </p>
+      <div className="flex flex-col sm:flex-row justify-center gap-6">
+        <Link to="/about#mission" className="text-brand-primary underline" aria-label="Company Mission">
+          Company Mission
+        </Link>
+        <Link to="/about#team" className="text-brand-primary underline" aria-label="Leadership">
+          Leadership
+        </Link>
+        <Link to="/about#press" className="text-brand-primary underline" aria-label="Press Kit">
+          Press Kit
+        </Link>
+      </div>
+    </div>
+  </section>
+);
+
+export default AboutSection;
+

--- a/src/components/FeaturesSection.tsx
+++ b/src/components/FeaturesSection.tsx
@@ -1,36 +1,42 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Brain, Target, TrendingUp, Users, Zap, Shield } from "lucide-react";
+import { Map, Layers, Bot, BarChart3, Plug } from "lucide-react";
+import { Link } from "react-router-dom";
 
 const features = [
   {
-    icon: Brain,
-    title: "AI-Powered Assessment",
-    description: "Our sophisticated AI analyzes your personality, skills, and goals to create a comprehensive profile."
-  },
-  {
-    icon: Target,
+    icon: Map,
     title: "Personalized Roadmaps",
-    description: "Get step-by-step action plans tailored specifically to your unique career aspirations and learning style."
+    description: "Tailored career paths to help you reach your unique goals.",
+    link: "/planner#roadmaps",
+    iconAlt: "Roadmap icon"
   },
   {
-    icon: TrendingUp,
-    title: "Dynamic Adaptation",
-    description: "Your roadmap evolves as you grow, ensuring recommendations stay relevant to your changing goals."
+    icon: Layers,
+    title: "Adaptive Learning Paths",
+    description: "Dynamic learning modules that adjust to your progress.",
+    link: "/planner#learning",
+    iconAlt: "Layered learning icon"
   },
   {
-    icon: Users,
-    title: "Expert-Backed Insights",
-    description: "Built on frameworks used by top career counselors and validated by industry professionals."
+    icon: Bot,
+    title: "Real-Time AI Coaching",
+    description: "Instant guidance and feedback powered by AI.",
+    link: "/planner#coaching",
+    iconAlt: "AI coaching icon"
   },
   {
-    icon: Zap,
-    title: "Instant Guidance",
-    description: "Get immediate answers to career questions and personalized advice whenever you need it."
+    icon: BarChart3,
+    title: "Progress Analytics",
+    description: "Track your growth with intuitive analytics.",
+    link: "/planner#analytics",
+    iconAlt: "Analytics icon"
   },
   {
-    icon: Shield,
-    title: "Privacy-First Approach",
-    description: "Your personal data and career information are protected with enterprise-grade security."
+    icon: Plug,
+    title: "Seamless Integrations",
+    description: "Connect with your favorite tools and platforms effortlessly.",
+    link: "/planner#integrations",
+    iconAlt: "Integration plug icon"
   }
 ];
 
@@ -52,21 +58,29 @@ const FeaturesSection = () => {
         
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
           {features.map((feature, index) => (
-            <Card key={index} className="group hover:shadow-lg hover:shadow-brand-primary/10 transition-all duration-300 border-border/50 hover:border-brand-primary/30">
-              <CardHeader>
-                <div className="w-12 h-12 rounded-lg bg-gradient-to-r from-brand-primary to-brand-secondary p-2.5 mb-4 group-hover:scale-110 transition-transform duration-300">
-                  <feature.icon className="w-full h-full text-white" />
-                </div>
-                <CardTitle className="text-xl font-semibold group-hover:text-brand-primary transition-colors">
-                  {feature.title}
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <CardDescription className="text-base leading-relaxed">
-                  {feature.description}
-                </CardDescription>
-              </CardContent>
-            </Card>
+            <Link
+              key={index}
+              to={feature.link}
+              className="group block hover:shadow-lg hover:shadow-brand-primary/10 transition-all duration-300 rounded-lg"
+              aria-label={feature.title}
+            >
+              <Card className="h-full border-border/50 group-hover:border-brand-primary/30">
+                <CardHeader>
+                  <div className="w-12 h-12 rounded-lg bg-gradient-to-r from-brand-primary to-brand-secondary p-2.5 mb-4 group-hover:scale-110 transition-transform duration-300">
+                    <feature.icon className="w-full h-full text-white" aria-hidden="true" />
+                    <span className="sr-only">{feature.iconAlt}</span>
+                  </div>
+                  <CardTitle className="text-xl font-semibold group-hover:text-brand-primary transition-colors">
+                    {feature.title}
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <CardDescription className="text-base leading-relaxed">
+                    {feature.description}
+                  </CardDescription>
+                </CardContent>
+              </Card>
+            </Link>
           ))}
         </div>
       </div>

--- a/src/components/FeaturesSection.tsx
+++ b/src/components/FeaturesSection.tsx
@@ -59,7 +59,7 @@ const FeaturesSection = () => {
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
           {features.map((feature, index) => (
             <Link
-              key={index}
+              key={feature.link}
               to={feature.link}
               className="group block hover:shadow-lg hover:shadow-brand-primary/10 transition-all duration-300 rounded-lg"
               aria-label={feature.title}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,9 +1,51 @@
 import React from "react";
+import { Link } from "react-router-dom";
+import { Twitter, Linkedin, Youtube } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
 
 const Footer = () => {
   return (
     <footer className="bg-background/80 backdrop-blur-md border-t border-border/50">
-      <div className="container mx-auto px-4 py-6 text-center text-sm text-muted-foreground">
+      <div className="container mx-auto px-4 py-12 grid gap-8 sm:grid-cols-2 md:grid-cols-4 text-sm">
+        <div>
+          <h3 className="font-semibold mb-4">Quick Links</h3>
+          <ul className="space-y-2">
+            <li><Link to="/">Home</Link></li>
+            <li><a href="#how-it-works">How It Works</a></li>
+            <li><a href="#features">Features</a></li>
+            <li><a href="#about">About</a></li>
+            <li><Link to="/pricing">Pricing</Link></li>
+            <li><Link to="/resources">Resources</Link></li>
+            <li><Link to="/careers">Careers</Link></li>
+            <li><Link to="/contact">Contact</Link></li>
+          </ul>
+        </div>
+        <div>
+          <h3 className="font-semibold mb-4">Legal</h3>
+          <ul className="space-y-2">
+            <li><Link to="/terms">Terms of Service</Link></li>
+            <li><Link to="/privacy">Privacy Policy</Link></li>
+            <li><Link to="/cookies">Cookie Policy</Link></li>
+          </ul>
+        </div>
+        <div>
+          <h3 className="font-semibold mb-4">Follow Us</h3>
+          <div className="flex gap-4">
+            <a href="https://www.linkedin.com" aria-label="LinkedIn"><Linkedin className="h-5 w-5" aria-hidden="true" /></a>
+            <a href="https://twitter.com" aria-label="Twitter"><Twitter className="h-5 w-5" aria-hidden="true" /></a>
+            <a href="https://www.youtube.com" aria-label="YouTube"><Youtube className="h-5 w-5" aria-hidden="true" /></a>
+          </div>
+        </div>
+        <div>
+          <h3 className="font-semibold mb-4">Newsletter</h3>
+          <form action="/newsletter" className="flex flex-col sm:flex-row gap-2">
+            <Input type="email" placeholder="Email address" aria-label="Email address" />
+            <Button type="submit">Subscribe</Button>
+          </form>
+        </div>
+      </div>
+      <div className="container mx-auto px-4 pb-6 text-center text-sm text-muted-foreground">
         © {new Date().getFullYear()} PersonaPath AI. All rights reserved.
       </div>
     </footer>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,36 +8,36 @@ const Header = () => {
       <div className="container mx-auto px-4">
         <div className="flex items-center justify-between h-16">
           {/* Logo */}
-          <div className="flex items-center gap-2">
+          <Link to="/" className="flex items-center gap-2" aria-label="PersonaPath AI Home">
             <div className="w-8 h-8 rounded-lg bg-gradient-to-r from-brand-primary to-brand-secondary flex items-center justify-center">
-              <Brain className="w-5 h-5 text-white" />
+              <Brain className="w-5 h-5 text-white" aria-hidden="true" />
             </div>
             <span className="text-xl font-bold">PersonaPath AI</span>
-          </div>
+          </Link>
           
           {/* Navigation */}
           <nav className="hidden md:flex items-center gap-8">
-            <a href="#features" className="text-muted-foreground hover:text-foreground transition-colors">
-              Features
-            </a>
+            <Link to="/" className="text-muted-foreground hover:text-foreground transition-colors">
+              Home
+            </Link>
             <a href="#how-it-works" className="text-muted-foreground hover:text-foreground transition-colors">
               How It Works
             </a>
+            <a href="#features" className="text-muted-foreground hover:text-foreground transition-colors">
+              Features
+            </a>
             <a href="#about" className="text-muted-foreground hover:text-foreground transition-colors">
               About
-            </a>
-            <a href="#contact" className="text-muted-foreground hover:text-foreground transition-colors">
-              Contact
             </a>
           </nav>
           
           {/* CTA Buttons */}
           <div className="hidden md:flex items-center gap-4">
-            <Button variant="ghost">
-              Sign In
+            <Button variant="ghost" asChild>
+              <Link to="/signin" aria-label="Sign In">Sign In</Link>
             </Button>
             <Button variant="brand" asChild>
-              <Link to="/planner">Get Started</Link>
+              <Link to="/signup" aria-label="Get Started">Get Started</Link>
             </Button>
           </div>
           

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -19,7 +19,7 @@ const HeroSection = () => {
         <div className="max-w-4xl mx-auto space-y-8">
           {/* Badge */}
           <div className="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-brand-primary/10 border border-brand-primary/20 text-brand-primary">
-            <Sparkles className="w-4 h-4" />
+            <Sparkles className="w-4 h-4" aria-hidden="true" />
             <span className="text-sm font-medium">AI-Powered Career Intelligence</span>
           </div>
           
@@ -41,13 +41,13 @@ const HeroSection = () => {
           {/* CTA Buttons */}
           <div className="flex flex-col sm:flex-row gap-4 justify-center items-center">
             <Button variant="hero" size="lg" className="text-lg px-8 py-6" asChild>
-              <Link to="/planner">
+              <Link to="/signup" aria-label="Start Your Journey">
                 Start Your Journey
-                <ArrowRight className="w-5 h-5" />
+                <ArrowRight className="w-5 h-5" aria-hidden="true" />
               </Link>
             </Button>
-            <Button variant="outline" size="lg" className="text-lg px-8 py-6">
-              Watch Demo
+            <Button variant="outline" size="lg" className="text-lg px-8 py-6" asChild>
+              <Link to="/demo" aria-label="Watch Demo">Watch Demo</Link>
             </Button>
           </div>
           

--- a/src/components/HowItWorksSection.tsx
+++ b/src/components/HowItWorksSection.tsx
@@ -1,111 +1,71 @@
-import { Card, CardContent } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { MessageSquare, Search, Route, Rocket } from "lucide-react";
+import { Link } from "react-router-dom";
+import { UserPlus, Brain, MessageSquare, BarChart3 } from "lucide-react";
 
 const steps = [
   {
+    icon: UserPlus,
+    title: "Create Your Profile",
+    description: "Answer a few questions to get started with your personalized journey.",
+    link: "/signup",
+    iconAlt: "User profile icon",
+  },
+  {
+    icon: Brain,
+    title: "AI-Generated Roadmap",
+    description: "Receive a tailored roadmap built around your goals and skills.",
+    link: "/planner",
+    iconAlt: "AI brain icon",
+  },
+  {
     icon: MessageSquare,
-    title: "Smart Assessment",
-    description: "Take our comprehensive AI-driven assessment that goes beyond traditional career tests to understand your unique profile.",
-    details: ["Personality analysis", "Skills evaluation", "Goal identification", "Values alignment"]
+    title: "Continuous Guidance",
+    description: "Get real-time support and advice whenever you need it.",
+    link: "/support",
+    iconAlt: "Chat guidance icon",
   },
   {
-    icon: Search,
-    title: "AI Analysis",
-    description: "Our advanced AI processes your responses to identify patterns, strengths, and opportunities tailored to you.",
-    details: ["Deep learning algorithms", "Pattern recognition", "Market insights", "Trend analysis"]
+    icon: BarChart3,
+    title: "Track Progress",
+    description: "Monitor your achievements and stay motivated along the way.",
+    link: "/dashboard",
+    iconAlt: "Progress chart icon",
   },
-  {
-    icon: Route,
-    title: "Custom Roadmap",
-    description: "Receive a detailed, actionable roadmap with specific steps, resources, and timelines for your success.",
-    details: ["Step-by-step plan", "Resource recommendations", "Timeline milestones", "Skill development paths"]
-  },
-  {
-    icon: Rocket,
-    title: "Continuous Growth",
-    description: "Your roadmap adapts as you progress, with ongoing AI guidance to keep you on track and motivated.",
-    details: ["Progress tracking", "Dynamic updates", "Real-time guidance", "Achievement recognition"]
-  }
 ];
 
-const HowItWorksSection = () => {
-  return (
-    <section className="py-24 bg-background">
-      <div className="container mx-auto px-4">
-        <div className="text-center mb-16">
-          <h2 className="text-4xl md:text-5xl font-bold mb-4">
-            How{" "}
-            <span className="bg-gradient-to-r from-brand-primary to-brand-secondary bg-clip-text text-transparent">
-              It Works
-            </span>
-          </h2>
-          <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
-            Our proven 4-step process transforms your career aspirations into actionable reality
-          </p>
-        </div>
-        
-        <div className="max-w-6xl mx-auto">
-          {steps.map((step, index) => (
-            <div key={index} className="relative">
-              {/* Connector Line */}
-              {index < steps.length - 1 && (
-                <div className="hidden lg:block absolute left-1/2 top-32 w-px h-24 bg-gradient-to-b from-brand-primary to-brand-secondary opacity-30 -translate-x-px" />
-              )}
-              
-              <div className={`flex flex-col lg:flex-row items-center gap-8 mb-16 ${
-                index % 2 === 1 ? 'lg:flex-row-reverse' : ''
-              }`}>
-                {/* Content */}
-                <div className="flex-1 lg:max-w-lg">
-                  <div className="flex items-center gap-4 mb-4">
-                    <div className="w-12 h-12 rounded-full bg-gradient-to-r from-brand-primary to-brand-secondary flex items-center justify-center text-white font-bold text-lg">
-                      {index + 1}
-                    </div>
-                    <h3 className="text-2xl font-bold">{step.title}</h3>
-                  </div>
-                  
-                  <p className="text-lg text-muted-foreground mb-6 leading-relaxed">
-                    {step.description}
-                  </p>
-                  
-                  <ul className="space-y-2 mb-6">
-                    {step.details.map((detail, detailIndex) => (
-                      <li key={detailIndex} className="flex items-center gap-2 text-muted-foreground">
-                        <div className="w-1.5 h-1.5 rounded-full bg-brand-primary" />
-                        {detail}
-                      </li>
-                    ))}
-                  </ul>
-                </div>
-                
-                {/* Icon Card */}
-                <div className="flex-1 lg:max-w-md">
-                  <Card className="p-8 bg-gradient-to-br from-brand-primary/5 to-brand-secondary/5 border-brand-primary/20 hover:shadow-lg hover:shadow-brand-primary/10 transition-all duration-300">
-                    <CardContent className="p-0 text-center">
-                      <div className="w-24 h-24 mx-auto mb-6 rounded-full bg-gradient-to-r from-brand-primary to-brand-secondary p-6">
-                        <step.icon className="w-full h-full text-white" />
-                      </div>
-                      <h4 className="text-xl font-semibold mb-2">{step.title}</h4>
-                      <p className="text-muted-foreground">
-                        Step {index + 1} of our personalized journey
-                      </p>
-                    </CardContent>
-                  </Card>
-                </div>
-              </div>
-            </div>
-          ))}
-        </div>
-        
-        <div className="text-center mt-16">
-          <Button variant="hero" size="lg" className="text-lg px-8 py-6">
-            Start Your Assessment
-          </Button>
-        </div>
+const HowItWorksSection = () => (
+  <section id="how-it-works" className="py-24 bg-background">
+    <div className="container mx-auto px-4">
+      <div className="text-center mb-16">
+        <h2 className="text-4xl md:text-5xl font-bold mb-4">
+          How <span className="bg-gradient-to-r from-brand-primary to-brand-secondary bg-clip-text text-transparent">It Works</span>
+        </h2>
+        <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
+          Our streamlined process connects you with the guidance you need.
+        </p>
       </div>
-    </section>
-  );
-};
+
+      <div className="grid gap-12 md:grid-cols-4">
+        {steps.map((step, index) => (
+          <Link
+            key={index}
+            to={step.link}
+            className="group text-center space-y-4"
+            aria-label={step.title}
+          >
+            <div className="w-16 h-16 mx-auto rounded-full bg-gradient-to-r from-brand-primary to-brand-secondary flex items-center justify-center">
+              <step.icon className="w-8 h-8 text-white" aria-hidden="true" />
+              <span className="sr-only">{step.iconAlt}</span>
+            </div>
+            <h3 className="text-xl font-semibold group-hover:text-brand-primary transition-colors">
+              {step.title}
+            </h3>
+            <p className="text-muted-foreground">{step.description}</p>
+          </Link>
+        ))}
+      </div>
+    </div>
+  </section>
+);
 
 export default HowItWorksSection;
+

--- a/src/components/HowItWorksSection.tsx
+++ b/src/components/HowItWorksSection.tsx
@@ -47,7 +47,7 @@ const HowItWorksSection = () => (
       <div className="grid gap-12 md:grid-cols-4">
         {steps.map((step, index) => (
           <Link
-            key={index}
+            key={step.link}
             to={step.link}
             className="group text-center space-y-4"
             aria-label={step.title}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -2,6 +2,7 @@ import Header from "@/components/Header";
 import HeroSection from "@/components/HeroSection";
 import FeaturesSection from "@/components/FeaturesSection";
 import HowItWorksSection from "@/components/HowItWorksSection";
+import AboutSection from "@/components/AboutSection";
 import ContactSection from "@/components/ContactSection";
 import Footer from "@/components/Footer";
 
@@ -13,6 +14,7 @@ const Index = () => {
         <HeroSection />
         <FeaturesSection />
         <HowItWorksSection />
+        <AboutSection />
         <ContactSection />
       </main>
       <Footer />


### PR DESCRIPTION
## Summary
- expand header with home navigation, sign-in, and get started links
- link hero CTAs to signup and demo
- add feature, how-it-works, about, and footer sections with accessible links

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c522b13dc08329b1ad0e4e3f5155a0